### PR TITLE
Syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ It currently supports:
 
 An example of using esri-polymer is shown in the esri-polymer.html page in the repository. Usage is as so:
 
+``` HTML
     <esri-map basemap="dark-gray" centerLng="-0.122" centerLat="51.514" zoom="7">
         <esri-featurelayer featurelayer="http://services.arcgis.com/Qo2anKIAMzIEkIJB/arcgis/rest/services/TubeMap/FeatureServer/2"> </esri-featurelayer>
         <esri-marker lng="-0.5" lat="51.3">
@@ -32,12 +33,13 @@ An example of using esri-polymer is shown in the esri-polymer.html page in the r
             <esri-marker-content>Some Content</esri-marker-content>
         </esri-marker>
     </esri-map>
-    
+```
 For generating a web map from an ID:
 
+``` HTML
     <esri-map webMapId="8960fbd6893348709acac9e7a3b61f0c">
     </esri-map>
-    
+```
 
 #Live Demo
 

--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ It currently supports:
 An example of using esri-polymer is shown in the esri-polymer.html page in the repository. Usage is as so:
 
 ``` HTML
-    <esri-map basemap="dark-gray" centerLng="-0.122" centerLat="51.514" zoom="7">
-        <esri-featurelayer featurelayer="http://services.arcgis.com/Qo2anKIAMzIEkIJB/arcgis/rest/services/TubeMap/FeatureServer/2"> </esri-featurelayer>
-        <esri-marker lng="-0.5" lat="51.3">
-            <esri-marker-title>Hello World</esri-marker-title>
-            <esri-marker-content>Some Content</esri-marker-content>
-        </esri-marker>
-    </esri-map>
+<esri-map basemap="dark-gray" centerLng="-0.122" centerLat="51.514" zoom="7">
+  <esri-featurelayer featurelayer="http://services.arcgis.com/Qo2anKIAMzIEkIJB/arcgis/rest/services/TubeMap/FeatureServer/2"></esri-featurelayer>
+  <esri-marker lng="-0.5" lat="51.3">
+    <esri-marker-title>Hello World</esri-marker-title>
+    <esri-marker-content>Some Content</esri-marker-content>
+  </esri-marker>
+</esri-map>
 ```
 For generating a web map from an ID:
 
 ``` HTML
-    <esri-map webMapId="8960fbd6893348709acac9e7a3b61f0c">
-    </esri-map>
+<esri-map webMapId="8960fbd6893348709acac9e7a3b61f0c">
+</esri-map>
 ```
 
 #Live Demo


### PR DESCRIPTION
Reformat the code samples using the backquote block syntax to specify HTML and colour-code the sample properly.
